### PR TITLE
[Refactor]challenge player coordinator

### DIFF
--- a/HotChal/HotChal/Coordinator/ChallengePlayerCoordinator.swift
+++ b/HotChal/HotChal/Coordinator/ChallengePlayerCoordinator.swift
@@ -8,22 +8,18 @@
 import UIKit
 
 /// 플레이어 매니저
-final class ChallengePlayerUIManager: GetKeyWindowProtocol {
-  static let shared = ChallengePlayerUIManager()
+class ChallengePlayerCoordinator: BaseCoordinator,
+                                  GetKeyWindowProtocol {
   
-  private init() {}
+  private weak var playerView: ChallPlayerView?
   
-  var playerView: ChallPlayerView?
-
   /// 플레이어 UI 보여주기
   func showChallPlayer(from viewController: UIViewController, data: ChallengeVideo){
-    guard playerView?.superview == nil else { return }
-      
     let playerView = ChallPlayerView(challenge: data)
     self.playerView = playerView
-     
+    
     guard let keyWindow = getKeyWindow() else { return }
-  
+    
     let buttonTitle = viewController is SavedHotChallViewController ? "삭제하기" : "즐겨찾기"
     let buttonImage = viewController is SavedHotChallViewController ? "trash" : "star"
     playerView.changeButton(title: buttonTitle, image: buttonImage)
@@ -40,14 +36,13 @@ final class ChallengePlayerUIManager: GetKeyWindowProtocol {
         playerView.centerXAnchor.constraint(equalTo: keyWindow.centerXAnchor),
         playerView.leadingAnchor.constraint(equalTo: keyWindow.leadingAnchor),
         playerView.trailingAnchor.constraint(equalTo: keyWindow.trailingAnchor),
-        playerView.bottomAnchor.constraint(equalTo: keyWindow.bottomAnchor, constant: -tabBarHeight)
+        playerView.bottomAnchor.constraint(equalTo: keyWindow.bottomAnchor,
+                                           constant: -tabBarHeight)
       ])
-      
     }
     
-    
     playerView.alpha = 0
-
+    
     UIView.animate(withDuration: 0.3) {
       self.playerView?.alpha = 1
       self.playerView?.transform = .identity
@@ -57,14 +52,17 @@ final class ChallengePlayerUIManager: GetKeyWindowProtocol {
     playerView.challengeData = data
   }
   
+  
+  /// 챌린지 플레이어 닫기
   func closeChallPlayer() {
-    guard playerView?.superview != nil else { return }
-
-      UIView.animate(withDuration: 0.3, animations: {
-        self.playerView?.alpha = 0
-      }) { _ in
-        self.playerView?.removeFromSuperview()
-      }
+    guard playerView != nil else { return }
+    
+    UIView.animate(withDuration: 0.3, animations: {
+      self.playerView?.alpha = 0
+    }) { _ in
+      self.playerView?.removeFromSuperview()
+      self.playerView = nil
+    }
   }
-
 }
+

--- a/HotChal/HotChal/DesignSytem/Soruces/Components/CustomView/ChallPlayerView.swift
+++ b/HotChal/HotChal/DesignSytem/Soruces/Components/CustomView/ChallPlayerView.swift
@@ -14,14 +14,14 @@ protocol ChallengePlayerViewDelegate: AnyObject {
   func navToShowChallenge(with data: ChallengeVideo)
   func navToTakeChallenge(with data: ChallengeVideo)
   func saveChallenge(with data: ChallengeVideo)
-  func closePlayerUI()
+  //  func closePlayerUI()
 }
-
-extension ChallengePlayerViewDelegate {
-  func closePlayerUI(){
-    ChallengePlayerUIManager.shared.closeChallPlayer()
-  }
-}
+//
+//extension ChallengePlayerViewDelegate {
+//  func closePlayerUI(){
+//    ChallengePlayerUIManager.shared.closeChallPlayer()
+//  }
+//}
 
 /// 챌린지 영상 플레이어 UIView
 final class ChallPlayerView: UIView {
@@ -66,6 +66,7 @@ final class ChallPlayerView: UIView {
   }()
   
   init(challenge: ChallengeVideo) {
+    print("ChallPlayerView init")
     self.challengeData = challenge
     
     super.init(frame: .zero)
@@ -80,6 +81,9 @@ final class ChallPlayerView: UIView {
     fatalError("init(coder:) has not been implemented")
   }
   
+  deinit {
+    print("ChallPlayerView deinit")
+  }
   
   /// UI 설정
   private func setupLayout(){
@@ -114,32 +118,36 @@ final class ChallPlayerView: UIView {
     
     learnChallengeButton.addAction(UIAction { [weak self] _ in
       guard let self = self else { return }
+      self.closeChallPlayer()
       self.delegate?.navToLearnChallenge(with: challengeData)
       
     }, for: .touchUpInside)
     
     saveChallengeButton.addAction(UIAction { [weak self] _ in
       guard let self = self else { return }
+      self.closeChallPlayer()
       self.delegate?.saveChallenge(with: challengeData)
     }, for: .touchUpInside)
     
     takeChallengeButton.addAction(UIAction { [weak self] _ in
       guard let self = self else { return }
+      self.closeChallPlayer()
       self.delegate?.navToTakeChallenge(with: challengeData)
     }, for: .touchUpInside)
     
     showChallengeButton.addAction(UIAction { [weak self] _ in
       guard let self = self else { return }
+      self.closeChallPlayer()
       self.delegate?.navToShowChallenge(with: challengeData)
     }, for: .touchUpInside)
     
     closePlayerButton.addAction(UIAction { [weak self] _ in
       guard let self = self else { return }
-      self.delegate?.closePlayerUI()
+      self.closeChallPlayer()
     }, for: .touchUpInside)
   }
   
-
+  
   /// 버튼 타이틀 변경  - 저장하기 / 삭제하기
   /// - Parameter title: 변경할 타이틀
   func changeButton(title: String, image: String) {
@@ -156,5 +164,14 @@ final class ChallPlayerView: UIView {
     saveChallengeButton.configuration = config
   }
   
+  func closeChallPlayer() {
+    guard self.superview != nil else { return }
+    
+    UIView.animate(withDuration: 0.3, animations: {
+      self.alpha = 0
+    }) { _ in
+      self.removeFromSuperview()
+    }
+  }
   
 }

--- a/HotChal/HotChal/Managers/ToastPopupManager.swift
+++ b/HotChal/HotChal/Managers/ToastPopupManager.swift
@@ -13,7 +13,7 @@ final class ToastPopupManager: GetKeyWindowProtocol {
   static let shared = ToastPopupManager()
   
   private init() {}
-  
+    
   /// Toast Popup 띄우기
   /// - Parameters:
   ///   - message: Toast Popup 메세지(기본값 = 통신 실패 메세지)

--- a/HotChal/HotChal/Scene/Chal/Coordinator/ChalCoordinator.swift
+++ b/HotChal/HotChal/Scene/Chal/Coordinator/ChalCoordinator.swift
@@ -2,52 +2,61 @@
 import UIKit
 
 /// 핫첼 메인화면이동 코디네이터
-final class ChalCoordinator: BaseCoordinator {
-    
-    private var lastSubVideoFilename: String?
-    
-    override func start() {
-        let chalMainViewController = HotChalMainViewController()
-        chalMainViewController.delegate = self
-        self.navigationController.viewControllers = [chalMainViewController]
-    }
-    
-    /// 핫챌 Top100 VC로 이동하기
+final class ChalCoordinator: ChallengePlayerCoordinator {
+  
+  private var lastSubVideoFilename: String?
+  
+  override func start() {
+    let chalMainViewController = HotChalMainViewController()
+    chalMainViewController.coordinator = self
+    self.navigationController.viewControllers = [chalMainViewController]
+  }
+  
+  /// 핫챌 Top100 VC로 이동하기
   func navToHotChallTop100ViewController(type: HotChallTop100Case = .normal,
                                          title challengeName: String = "핫챌 Top20"){
-        let vc = HotChallTop100ViewController(vcType: type, navTitle: challengeName)
-
-        vc.delegate = self
-        self.navigationController.pushViewController(vc, animated: true)
-    }
-    /// 챌린지 배우기 디테일 화면으로 이동
-    func navToLearnChallengeViewController(with data: ChallengeVideo) {
-        let vc = PlayerViewController()
-        vc.challengeData = data
-        vc.hidesBottomBarWhenPushed = true
-        vc.coordinator = self
-        self.navigationController.pushViewController(vc, animated: true)
-    }
+    let vc = HotChallTop100ViewController(vcType: type, navTitle: challengeName)
     
-    // 챌린지 찍기 화면으로 이동
-    func navToTakeChallengeViewController(audioFileName: String, subVideoFilename: String?) {
-        lastSubVideoFilename = subVideoFilename
-        let cameraCoordinator = CameraCoordinator(navigationController: navigationController, audioFileName: audioFileName)
-        cameraCoordinator.delegate = self
-        cameraCoordinator.finishDelegate = self
-        childCoordinators.append(cameraCoordinator)
-        cameraCoordinator.start()
-    }
-
-    func navToCompareViewController(url: URL) {
-        let vc = ChallCompareViewController()
-        vc.videoURL = url
-        vc.subVideoFilename = lastSubVideoFilename
-        vc.coordinator = self
-        vc.hidesBottomBarWhenPushed = true
-        navigationController.pushViewController(vc, animated: true)
-    }
-    override func didFinishCameraRecording(url: URL) {
-        self.navToCompareViewController(url: url)
-    }
+    vc.coordinator = self
+    self.navigationController.pushViewController(vc, animated: true)
+  }
+  
+  /// 챌린지 배우기 디테일 화면으로 이동
+  func navToLearnChallengeViewController(with data: ChallengeVideo) {
+    let vc = PlayerViewController()
+    vc.challengeData = data
+    vc.hidesBottomBarWhenPushed = true
+    vc.coordinator = self
+    self.navigationController.pushViewController(vc, animated: true)
+  }
+  
+  // 챌린지 찍기 화면으로 이동
+  func navToTakeChallengeViewController(
+    audioFileName: String,
+    subVideoFilename: String?
+  ) {
+    lastSubVideoFilename = subVideoFilename
+    
+    let cameraCoordinator = CameraCoordinator(navigationController: navigationController,
+                                              audioFileName: audioFileName)
+    cameraCoordinator.delegate = self
+    cameraCoordinator.finishDelegate = self
+    childCoordinators.append(cameraCoordinator)
+    cameraCoordinator.start()
+  }
+  
+  
+  /// 찍은 챌린지 비교해보기 화면으로 이동
+  func navToCompareViewController(url: URL) {
+    let vc = ChallCompareViewController()
+    vc.videoURL = url
+    vc.subVideoFilename = lastSubVideoFilename
+    vc.coordinator = self
+    vc.hidesBottomBarWhenPushed = true
+    navigationController.pushViewController(vc, animated: true)
+  }
+  
+  override func didFinishCameraRecording(url: URL) {
+    self.navToCompareViewController(url: url)
+  }
 }

--- a/HotChal/HotChal/Scene/Chal/Features/HotChallTop100ViewController.swift
+++ b/HotChal/HotChal/Scene/Chal/Features/HotChallTop100ViewController.swift
@@ -18,7 +18,7 @@ enum HotChallTop100Case {
 /// HotChall - front - HotChallTop100ViewController
 /// 핫챌 Top100 화면
 final class HotChallTop100ViewController: UIViewController {
-  weak var delegate: ChallengeNavigationDelegate?
+  weak var coordinator: ChallengePlayerCoordinator?
   
   let vcType: HotChallTop100Case
   var challengeName: String
@@ -53,15 +53,17 @@ final class HotChallTop100ViewController: UIViewController {
   }
   
   override func loadView() {
+    super.loadView()
     self.view = mainView
   }
   
   override func viewWillDisappear(_ animated: Bool) {
-    ChallengePlayerUIManager.shared.closeChallPlayer()
+    super.viewWillDisappear(true)
+    coordinator?.closeChallPlayer()
   }
 
   func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    ChallengePlayerUIManager.shared.closeChallPlayer()
+    coordinator?.closeChallPlayer()
   }
   
   /// collectionView 설정
@@ -125,9 +127,11 @@ extension HotChallTop100ViewController: UICollectionViewDelegateFlowLayout{
     didSelectItemAt indexPath: IndexPath
   ) {
     let challengeData: ChallengeVideo = challengeDatas[indexPath.item]
+    
+    coordinator?.showChallPlayer(from: self, data: challengeData)
+    
 
-    ChallengePlayerUIManager.shared.showChallPlayer(from: self, data: challengeData)
-
+//    delegate?.showcha(from: self, data: challengeData)
   }
   
   func collectionView(
@@ -149,24 +153,23 @@ extension HotChallTop100ViewController: ChallengePlayerViewDelegate {
     func navToTakeChallenge(with data: ChallengeVideo) {
 
         let audioName = data.mp4FilenameWithoutExtension ?? (data.videoFilename ?? "")
-        delegate?.navToTakeChallengeViewController(
+        coordinator?.navToTakeChallengeViewController(
             audioFileName: audioName,
             subVideoFilename: data.videoFilename
         )
     }
   
   func navToLearnChallenge(with data: ChallengeVideo) {
-    delegate?.navToLearnChallengeViewController(with: data)
+    coordinator?.navToLearnChallengeViewController(with: data)
   }
   
   func navToShowChallenge(with data: ChallengeVideo) {
     guard let challenge = data.videoFilename else { return }
-    delegate?.navToShowChallengeViewController(with: challenge)
+    coordinator?.navToShowChallengeViewController(with: challenge)
   }
   
   func saveChallenge(with data: ChallengeVideo) {
     CoreDataManager.shared.saveChallenge(with: data) { result in
-      ChallengePlayerUIManager.shared.closeChallPlayer()
       let comment = result ? "챌린지가 저장되었습니다." : "이미 저장된 챌린지입니다."
       
       ToastPopupManager.shared.showToast(message: comment, from: self)

--- a/HotChal/HotChal/Scene/Chal/HotChalMainScene/HotChalMainViewController.swift
+++ b/HotChal/HotChal/Scene/Chal/HotChalMainScene/HotChalMainViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 /// 핫챌 메인 화면
 final class HotChalMainViewController: UIViewController {
   
-  weak var delegate: ChalCoordinator?
+  weak var coordinator: ChalCoordinator?
   
   private let mainView: HotChalMainView = HotChalMainView()
   
@@ -39,11 +39,11 @@ final class HotChalMainViewController: UIViewController {
   
   override func viewWillDisappear(_ animated: Bool) {
     super.viewWillDisappear(animated)
-    ChallengePlayerUIManager.shared.closeChallPlayer()
+    coordinator?.closeChallPlayer()
   }
   
   func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    ChallengePlayerUIManager.shared.closeChallPlayer()
+    coordinator?.closeChallPlayer()
   }
   
   /// 셀 delegate 및 dataSource 설정
@@ -66,7 +66,7 @@ final class HotChalMainViewController: UIViewController {
   /// 버튼 액션 추가하기
   private func addButtonActions(){
     mainView.topMoreButton.addAction(UIAction { [weak self] _ in
-      self?.delegate?.navToHotChallTop100ViewController()
+      self?.coordinator?.navToHotChallTop100ViewController()
     } , for: .touchUpInside)
     
     // 카테고리 별 전체보기 버튼을 찾아서 버튼 액션 달아주기
@@ -78,7 +78,7 @@ final class HotChalMainViewController: UIViewController {
       guard let challengeName = $0.titleLabel.text else { return }
       
       $0.moreButton.addAction(UIAction { [weak self] _ in
-        self?.delegate?.navToHotChallTop100ViewController(type: .category, title: challengeName)
+        self?.coordinator?.navToHotChallTop100ViewController(type: .category, title: challengeName)
       }, for: .touchUpInside)
     }
   }
@@ -163,7 +163,8 @@ extension HotChalMainViewController: UICollectionViewDelegateFlowLayout{
     }
     
     if let data = challengeData {
-      ChallengePlayerUIManager.shared.showChallPlayer(from: self, data: data)
+//      ChallengePlayerUIManager.shared.showChallPlayer(from: self, data: data)
+      coordinator?.showChallPlayer(from: self, data: data)
     }
   }
 
@@ -189,25 +190,24 @@ extension HotChalMainViewController: UICollectionViewDelegateFlowLayout{
 extension HotChalMainViewController: ChallengePlayerViewDelegate {
   func navToTakeChallenge(with data: ChallengeVideo) {
 
-    delegate?.navToTakeChallengeViewController(
+    coordinator?.navToTakeChallengeViewController(
       audioFileName: data.videoFilename ?? "",
       subVideoFilename: data.videoFilename
     )
   }
   
   func navToLearnChallenge(with data: ChallengeVideo) {
-    delegate?.navToLearnChallengeViewController(with: data)
+    coordinator?.navToLearnChallengeViewController(with: data)
   }
   
   func navToShowChallenge(with data: ChallengeVideo) {
     guard let challenge = data.videoFilename else { return }
     //    ChallengePlayerManager.shared.playLocalVideo(named: challenge, from: self)
-    delegate?.navToShowChallengeViewController(with: challenge)
+    coordinator?.navToShowChallengeViewController(with: challenge)
   }
   
   func saveChallenge(with data: ChallengeVideo) {
     CoreDataManager.shared.saveChallenge(with: data) { result in
-      ChallengePlayerUIManager.shared.closeChallPlayer()
       let comment = result ? "챌린지가 저장되었습니다." : "이미 저장된 챌린지입니다."
       
       ToastPopupManager.shared.showToast(message: comment, from: self)

--- a/HotChal/HotChal/Scene/Learn/Coordinator/HotChallLearnCoordinator.swift
+++ b/HotChal/HotChal/Scene/Learn/Coordinator/HotChallLearnCoordinator.swift
@@ -9,13 +9,13 @@ import UIKit
 
 
 /// 챌린지  배우기 코디네이터
-final class HotChallLearnCoordinator: BaseCoordinator {
+final class HotChallLearnCoordinator: ChallengePlayerCoordinator {
     
     private var lastSubVideoFilename: String?
 
   override func start() {
     let HotChallLearnViewController = HotChallLearnViewController()
-    HotChallLearnViewController.delegate = self
+    HotChallLearnViewController.coordinator = self
     
     self.navigationController.viewControllers = [HotChallLearnViewController]
     

--- a/HotChal/HotChal/Scene/Learn/HotChallLearnViewController.swift
+++ b/HotChal/HotChal/Scene/Learn/HotChallLearnViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 /// 챌린지 배우기 화면
 final class HotChallLearnViewController: UIViewController {
   
-  weak var delegate: HotChallLearnCoordinator?
+  weak var coordinator: HotChallLearnCoordinator?
   
   var searchTimer: Timer?
 
@@ -64,17 +64,17 @@ final class HotChallLearnViewController: UIViewController {
   
   override func viewWillDisappear(_ animated: Bool) {
     super.viewWillDisappear(animated)
-    ChallengePlayerUIManager.shared.closeChallPlayer()
+    coordinator?.closeChallPlayer()
   }
   
   func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    ChallengePlayerUIManager.shared.closeChallPlayer()
+    coordinator?.closeChallPlayer()
   }
   
   override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-    ChallengePlayerUIManager.shared.closeChallPlayer()
-
+    super.touchesBegan(touches, with: event)
     view.endEditing(true)
+    coordinator?.closeChallPlayer()
   }
   
   // collectionView 설정
@@ -184,8 +184,7 @@ extension HotChallLearnViewController: UICollectionViewDelegateFlowLayout{
 
     let challengeData: ChallengeVideo = challengeDatas[indexPath.item]
 
-    ChallengePlayerUIManager.shared.showChallPlayer(from: self, data: challengeData)
-
+    coordinator?.showChallPlayer(from: self, data: challengeData)
   }
   
   func collectionView(
@@ -202,24 +201,23 @@ extension HotChallLearnViewController: UICollectionViewDelegateFlowLayout{
 
 extension HotChallLearnViewController: ChallengePlayerViewDelegate {
   func navToTakeChallenge(with data: ChallengeVideo) {
-    delegate?.navToTakeChallengeViewController(
+    coordinator?.navToTakeChallengeViewController(
       audioFileName: data.mp4FilenameWithoutExtension ?? "",
       subVideoFilename: data.videoFilename
     )
   }
   
   func navToLearnChallenge(with data: ChallengeVideo) {
-    delegate?.navToLearnChallengeViewController(with: data)
+    coordinator?.navToLearnChallengeViewController(with: data)
   }
   
   func navToShowChallenge(with data: ChallengeVideo) {
     guard let challenge = data.videoFilename else { return }
-    delegate?.navToShowChallengeViewController(with: challenge)
+    coordinator?.navToShowChallengeViewController(with: challenge)
   }
   
   func saveChallenge(with data: ChallengeVideo) {
     CoreDataManager.shared.saveChallenge(with: data) { result in
-      ChallengePlayerUIManager.shared.closeChallPlayer()
       
       let comment = result ? "챌린지가 저장되었습니다." : "이미 저장된 챌린지입니다."
       ToastPopupManager.shared.showToast(message: comment, from: self)
@@ -265,8 +263,6 @@ extension HotChallLearnViewController: UISearchBarDelegate {
   }
   
   func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
-    ChallengePlayerUIManager.shared.closeChallPlayer()
-
     view.endEditing(true)
   }
 }

--- a/HotChal/HotChal/Scene/Learn/Player/PlayerViewController.swift
+++ b/HotChal/HotChal/Scene/Learn/Player/PlayerViewController.swift
@@ -342,7 +342,7 @@ final class PlayerViewController: UIViewController, ModalViewControllerProtocol 
         guard let self = self,
               let data = self.challengeData else { return }
         CoreDataManager.shared.saveChallenge(with: data) { result in
-          ChallengePlayerUIManager.shared.closeChallPlayer()
+//          ChallengePlayerUIManager.shared.closeChallPlayer()
           let comment = result ? "챌린지가 저장되었습니다." : "이미 저장된 챌린지입니다."
           
           ToastPopupManager.shared.showToast(message: comment, from: self)

--- a/HotChal/HotChal/Scene/SavedChallenge/Coordinator/SavedChallengeCoordinator.swift
+++ b/HotChal/HotChal/Scene/SavedChallenge/Coordinator/SavedChallengeCoordinator.swift
@@ -9,13 +9,13 @@ import UIKit
 
 
 /// 저장된 챌린지 코디네이터
-final class SavedChallengeCoordinator: BaseCoordinator {
+final class SavedChallengeCoordinator: ChallengePlayerCoordinator {
     
     private var lastSubVideoFilename: String?
   
   override func start() {
     let favoriteViewController = SavedHotChallViewController()
-    favoriteViewController.delegate = self
+    favoriteViewController.coordinator = self
     
     self.navigationController.viewControllers = [favoriteViewController]
     
@@ -24,7 +24,7 @@ final class SavedChallengeCoordinator: BaseCoordinator {
   /// 핫챌 Top100 VC로 이동하기
   func navToHotChallTop100ViewController(with challengeName: String){
     let vc = HotChallTop100ViewController(vcType: .savedChallenge, navTitle: challengeName)
-    vc.delegate = self
+    vc.coordinator = self
     self.navigationController.pushViewController(vc, animated: true)
   }
     

--- a/HotChal/HotChal/Scene/SavedChallenge/SavedHotChallViewController.swift
+++ b/HotChal/HotChal/Scene/SavedChallenge/SavedHotChallViewController.swift
@@ -15,7 +15,7 @@ final class SavedHotChallViewController: UIViewController {
   
   private lazy var categories: [String] = []
   
-  weak var delegate: SavedChallengeCoordinator?
+  weak var coordinator: SavedChallengeCoordinator?
   
   var selectedChallengeUUID: UUID? = nil
   
@@ -50,11 +50,11 @@ final class SavedHotChallViewController: UIViewController {
   }
   
   override func viewWillDisappear(_ animated: Bool) {
-    ChallengePlayerUIManager.shared.closeChallPlayer()
+    coordinator?.closeChallPlayer()
   }
   
   func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    ChallengePlayerUIManager.shared.closeChallPlayer()
+    coordinator?.closeChallPlayer()
   }
   
   
@@ -200,7 +200,7 @@ extension SavedHotChallViewController: UICollectionViewDelegate {
     let category = categories[indexPath.section]
     guard let data: ChallengeVideo = divideWithCategory[category]?[indexPath.item] else { return }
 
-    ChallengePlayerUIManager.shared.showChallPlayer(from: self, data: data)
+    coordinator?.showChallPlayer(from: self, data: data)
 
   }
 }
@@ -218,7 +218,7 @@ extension SavedHotChallViewController {
 
 extension SavedHotChallViewController: ChallengeHeaderViewActionDelegate{
   func didTapShowAllContent(category: String) {
-    delegate?.navToHotChallTop100ViewController(with: category)
+    coordinator?.navToHotChallTop100ViewController(with: category)
   }
 }
 
@@ -227,19 +227,19 @@ extension SavedHotChallViewController: ChallengeHeaderViewActionDelegate{
 extension SavedHotChallViewController: ChallengePlayerViewDelegate {
   func navToTakeChallenge(with data: ChallengeVideo) {
 
-    delegate?.navToTakeChallengeViewController(
+    coordinator?.navToTakeChallengeViewController(
       audioFileName: data.mp4FilenameWithoutExtension ?? "",
       subVideoFilename: data.videoFilename
     )
   }
   
   func navToLearnChallenge(with data: ChallengeVideo) {
-    delegate?.navToLearnChallengeViewController(with: data)
+    coordinator?.navToLearnChallengeViewController(with: data)
   }
   
   func navToShowChallenge(with data: ChallengeVideo) {
     guard let challenge = data.videoFilename else { return }
-    delegate?.navToShowChallengeViewController(with: challenge)
+    coordinator?.navToShowChallengeViewController(with: challenge)
   }
   
   func saveChallenge(with data: ChallengeVideo) {
@@ -257,7 +257,6 @@ extension SavedHotChallViewController: SavedChallengeDelegate {
   func didTapDeleteButton() {
     guard let uuid = selectedChallengeUUID else { return }
     CoreDataManager.shared.deleteSavedChallenge(with: uuid) {
-      ChallengePlayerUIManager.shared.closeChallPlayer()
       ToastPopupManager.shared.showToast(message: "챌린지가 삭제되었습니다.", from: self)
       self.reloadData()
     }

--- a/HotChal/HotChal/Scene/ShowChallenge/ShowChallengeViewController.swift
+++ b/HotChal/HotChal/Scene/ShowChallenge/ShowChallengeViewController.swift
@@ -150,7 +150,7 @@ final class ShowChallengeViewController: UIViewController {
       guard let self = self,
             let data = self.challengeData else { return }
       CoreDataManager.shared.saveChallenge(with: data) { result in
-        ChallengePlayerUIManager.shared.closeChallPlayer()
+//        ChallengePlayerUIManager.shared.closeChallPlayer()
         let comment = result ? "챌린지가 저장되었습니다." : "이미 저장된 챌린지입니다."
         
         ToastPopupManager.shared.showToast(message: comment, from: self)


### PR DESCRIPTION
## Summary
PlayerView UI 관리 방식을 싱글턴에서 Coordinator로 변경하여 메모리 누수 및 화면 제어 분산 문제를 해결함

## Changes
- ChallengePlayerUIManager 싱글턴 제거
- ChallengePlayerCoordinator 추가
- PlayerView를 weak으로 관리하여 메모리 해제 문제 해결
- PlayerView show/close 로직을 Coordinator로 일원화

## Why
싱글턴으로 인해 PlayerView가 해제되지 않거나, 여러 화면에서 shared 접근으로 흐름이 분산되는 문제가 있어 구조 정리가 필요했음

## Test
- PlayerView 정상 표시/해제 확인 (Xcode Memory Graph Debugger 사용)
- 스크롤/화면 이동 시 deinit 정상 호출
