### PR TITLE
[Refactor]hotchall main to reactorkit

### DIFF
--- a/HotChal/HotChal.xcodeproj/project.pbxproj
+++ b/HotChal/HotChal.xcodeproj/project.pbxproj
@@ -6,6 +6,13 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		EE17A5F82ECAF6DB005FC40E /* ReactorKit in Frameworks */ = {isa = PBXBuildFile; productRef = EE17A5F72ECAF6DB005FC40E /* ReactorKit */; };
+		EE17A5FB2ECAF6F2005FC40E /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = EE17A5FA2ECAF6F2005FC40E /* RxCocoa */; };
+		EE17A5FD2ECAF6F2005FC40E /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = EE17A5FC2ECAF6F2005FC40E /* RxRelay */; };
+		EE17A5FF2ECAF6F2005FC40E /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = EE17A5FE2ECAF6F2005FC40E /* RxSwift */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXFileReference section */
 		9322F5752E384AEB00222654 /* HotChal.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HotChal.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -36,6 +43,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EE17A5FD2ECAF6F2005FC40E /* RxRelay in Frameworks */,
+				EE17A5FB2ECAF6F2005FC40E /* RxCocoa in Frameworks */,
+				EE17A5FF2ECAF6F2005FC40E /* RxSwift in Frameworks */,
+				EE17A5F82ECAF6DB005FC40E /* ReactorKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -78,6 +89,10 @@
 			);
 			name = HotChal;
 			packageProductDependencies = (
+				EE17A5F72ECAF6DB005FC40E /* ReactorKit */,
+				EE17A5FA2ECAF6F2005FC40E /* RxCocoa */,
+				EE17A5FC2ECAF6F2005FC40E /* RxRelay */,
+				EE17A5FE2ECAF6F2005FC40E /* RxSwift */,
 			);
 			productName = Moodie;
 			productReference = 9322F5752E384AEB00222654 /* HotChal.app */;
@@ -107,6 +122,10 @@
 			);
 			mainGroup = 9322F56C2E384AEB00222654;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				EE17A5F62ECAF6DB005FC40E /* XCRemoteSwiftPackageReference "ReactorKit" */,
+				EE17A5F92ECAF6F2005FC40E /* XCRemoteSwiftPackageReference "RxSwift" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 9322F5762E384AEB00222654 /* Products */;
 			projectDirPath = "";
@@ -347,6 +366,48 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		EE17A5F62ECAF6DB005FC40E /* XCRemoteSwiftPackageReference "ReactorKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ReactorKit/ReactorKit.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.2.0;
+			};
+		};
+		EE17A5F92ECAF6F2005FC40E /* XCRemoteSwiftPackageReference "RxSwift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ReactiveX/RxSwift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.9.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		EE17A5F72ECAF6DB005FC40E /* ReactorKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EE17A5F62ECAF6DB005FC40E /* XCRemoteSwiftPackageReference "ReactorKit" */;
+			productName = ReactorKit;
+		};
+		EE17A5FA2ECAF6F2005FC40E /* RxCocoa */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EE17A5F92ECAF6F2005FC40E /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxCocoa;
+		};
+		EE17A5FC2ECAF6F2005FC40E /* RxRelay */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EE17A5F92ECAF6F2005FC40E /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxRelay;
+		};
+		EE17A5FE2ECAF6F2005FC40E /* RxSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EE17A5F92ECAF6F2005FC40E /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxSwift;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 9322F56D2E384AEB00222654 /* Project object */;
 }

--- a/HotChal/HotChal.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/HotChal/HotChal.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "bf1d89f7becd6561e21b5ac1ad7af0bd3715d48d0e5641a3f27ebbd92ef6b298",
+  "pins" : [
+    {
+      "identity" : "reactorkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactorKit/ReactorKit.git",
+      "state" : {
+        "revision" : "8fa33f09c6f6621a2aa536d739956d53b84dd139",
+        "version" : "3.2.0"
+      }
+    },
+    {
+      "identity" : "rxswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveX/RxSwift.git",
+      "state" : {
+        "revision" : "5004a18539bd68905c5939aa893075f578f4f03d",
+        "version" : "6.9.1"
+      }
+    },
+    {
+      "identity" : "weakmaptable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactorKit/WeakMapTable.git",
+      "state" : {
+        "revision" : "cb05d64cef2bbf51e85c53adee937df46540a74e",
+        "version" : "1.2.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/HotChal/HotChal/Managers/MockupDataManager.swift
+++ b/HotChal/HotChal/Managers/MockupDataManager.swift
@@ -30,7 +30,7 @@ final class MockupDataManager {
 
   lazy var top3Categories = top3ChallengeVideos.map { $0.category }
   
-  lazy var top3ChallengeVideosWithCategory: [Int : [ChallengeVideo]] = [:]
+  lazy var top3ChallengeVideosWithCategory: [[ChallengeVideo]] = []
   
   lazy var sortedWithViewCountChallengeVideos: [ChallengeVideo] = []
 
@@ -49,7 +49,7 @@ final class MockupDataManager {
     for (num, category) in top3Categories.enumerated() {
       let challenges = challengeVideos.filter { $0.category == category }
       
-      top3ChallengeVideosWithCategory.updateValue(challenges, forKey: num)
+      top3ChallengeVideosWithCategory.append(challenges)
     }
     
     recommendChallengeVideos = Array(challengeVideos.shuffled().prefix(10))

--- a/HotChal/HotChal/Scene/Chal/Coordinator/ChalCoordinator.swift
+++ b/HotChal/HotChal/Scene/Chal/Coordinator/ChalCoordinator.swift
@@ -1,6 +1,12 @@
 
 import UIKit
 
+
+/// 핫챌 메인화면이동 이벤트목록
+enum HotChalMainNavigationEvent: Equatable {
+  case navTotop100VC(type: HotChallTop100Case, title: String)
+}
+
 /// 핫첼 메인화면이동 코디네이터
 final class ChalCoordinator: ChallengePlayerCoordinator {
   

--- a/HotChal/HotChal/Scene/Chal/Coordinator/ChalCoordinator.swift
+++ b/HotChal/HotChal/Scene/Chal/Coordinator/ChalCoordinator.swift
@@ -9,6 +9,7 @@ final class ChalCoordinator: ChallengePlayerCoordinator {
   override func start() {
     let chalMainViewController = HotChalMainViewController()
     chalMainViewController.coordinator = self
+    chalMainViewController.reactor = HotChalMainReactor()
     self.navigationController.viewControllers = [chalMainViewController]
   }
   
@@ -31,18 +32,20 @@ final class ChalCoordinator: ChallengePlayerCoordinator {
   }
   
   // 챌린지 찍기 화면으로 이동
+  // 이게 지금 lastSubVideo에 넣는 걸 코디네이터에서 하면 안되지
   func navToTakeChallengeViewController(
     audioFileName: String,
     subVideoFilename: String?
   ) {
     lastSubVideoFilename = subVideoFilename
+    super.navToTakeChallengeViewController(audioFileName: audioFileName)
     
-    let cameraCoordinator = CameraCoordinator(navigationController: navigationController,
-                                              audioFileName: audioFileName)
-    cameraCoordinator.delegate = self
-    cameraCoordinator.finishDelegate = self
-    childCoordinators.append(cameraCoordinator)
-    cameraCoordinator.start()
+//    let cameraCoordinator = CameraCoordinator(navigationController: navigationController,
+//                                              audioFileName: audioFileName)
+//    cameraCoordinator.delegate = self
+//    cameraCoordinator.finishDelegate = self
+//    childCoordinators.append(cameraCoordinator)
+//    cameraCoordinator.start()
   }
   
   

--- a/HotChal/HotChal/Scene/Chal/HotChalMainScene/HotChalMainReactor.swift
+++ b/HotChal/HotChal/Scene/Chal/HotChalMainScene/HotChalMainReactor.swift
@@ -1,0 +1,93 @@
+//
+//  HotChalMainReactor.swift
+//  HotChal
+//
+//  Created by 최용헌 on 11/17/25.
+//
+
+import ReactorKit
+import Foundation
+
+final class HotChalMainReactor: Reactor {
+  
+  // 사용자와의 interaction
+  enum Action {
+    case setupInititalDatas
+    case tapTopItem(IndexPath)
+    case tapCategoryItem(Int, IndexPath)
+    case tapMoreTopButton
+    case tapMoreCategoryButton
+  }
+  
+  // 데이터 가공
+  enum Mutation {
+    case setTop3Items([ChallengeVideo])
+    case setCategoryVideos([[ChallengeVideo]])
+    case setLoading(Bool)
+    case setSelectedChallenge(ChallengeVideo)
+  }
+  
+  // 화면에 보여줄 정보
+  struct State {
+    var isLoading: Bool = false
+    
+    var top3Challenge: [ChallengeVideo] = []
+    var categoryVideos: [[ChallengeVideo]] = []
+    
+    var selectedChallenge: ChallengeVideo? = nil
+  }
+  
+  var initialState: State
+
+  private let dataManager = MockupDataManager.shared
+  
+  init() {
+    self.initialState = State()
+  }
+  
+  // Action -> Mutation
+  func mutate(action: Action) -> Observable<Mutation> {
+    switch action {
+    case .setupInititalDatas:
+      let top3 = dataManager.top3ChallengeVideos
+      let categoryVideos = dataManager.top3ChallengeVideosWithCategory
+      return Observable.concat([
+        .just(.setLoading(true)),
+        .just(.setTop3Items(top3)),
+        .just(.setCategoryVideos(categoryVideos)),
+        .just(.setLoading(false))
+      ])
+    
+    case .tapTopItem(let indexPath):
+      let item = currentState.top3Challenge[indexPath.row]
+      return .just(.setSelectedChallenge(item))
+    
+    case .tapCategoryItem(let categoryIndex, let indexPath):
+      let item = currentState.categoryVideos[categoryIndex][indexPath.row]
+      return .just(.setSelectedChallenge(item))
+    
+    case .tapMoreTopButton:
+      return .empty()
+    case .tapMoreCategoryButton:
+      return .empty()
+    }
+  }
+  
+  // Mutation -> State
+  func reduce(state: State, mutation: Mutation) -> State {
+    var newState = state
+    
+    switch mutation {
+    case .setTop3Items(let top3):
+      newState.top3Challenge = top3
+    case .setCategoryVideos(let categoryList):
+      newState.categoryVideos = categoryList
+    case .setLoading(let isLoading):
+      newState.isLoading = isLoading
+    case .setSelectedChallenge(let item):
+      newState.selectedChallenge = item
+    }
+    
+    return newState
+  }
+}

--- a/HotChal/HotChal/Scene/Chal/HotChalMainScene/HotChalMainReactor.swift
+++ b/HotChal/HotChal/Scene/Chal/HotChalMainScene/HotChalMainReactor.swift
@@ -13,10 +13,10 @@ final class HotChalMainReactor: Reactor {
   // 사용자와의 interaction
   enum Action {
     case setupInititalDatas
-    case tapTopItem(IndexPath)
-    case tapCategoryItem(Int, IndexPath)
-    case tapMoreTopButton
-    case tapMoreCategoryButton
+    case tapTopItem(Int)
+    case tapCategoryItem(categoryIndex: Int, itemIndex: Int)
+    case tapMoreTopButton(String)
+    case tapMoreCategoryButton(String)
   }
   
   // 데이터 가공
@@ -25,6 +25,7 @@ final class HotChalMainReactor: Reactor {
     case setCategoryVideos([[ChallengeVideo]])
     case setLoading(Bool)
     case setSelectedChallenge(ChallengeVideo)
+    case setNavigation(HotChalMainNavigationEvent)
   }
   
   // 화면에 보여줄 정보
@@ -33,8 +34,9 @@ final class HotChalMainReactor: Reactor {
     
     var top3Challenge: [ChallengeVideo] = []
     var categoryVideos: [[ChallengeVideo]] = []
-    
+
     var selectedChallenge: ChallengeVideo? = nil
+    var navigation: HotChalMainNavigationEvent? = nil
   }
   
   var initialState: State
@@ -59,17 +61,18 @@ final class HotChalMainReactor: Reactor {
       ])
     
     case .tapTopItem(let indexPath):
-      let item = currentState.top3Challenge[indexPath.row]
+      let item = currentState.top3Challenge[indexPath]
       return .just(.setSelectedChallenge(item))
     
-    case .tapCategoryItem(let categoryIndex, let indexPath):
-      let item = currentState.categoryVideos[categoryIndex][indexPath.row]
+    case let .tapCategoryItem(categoryIndex, itemIndex):
+      let item = currentState.categoryVideos[categoryIndex][itemIndex]
       return .just(.setSelectedChallenge(item))
     
-    case .tapMoreTopButton:
-      return .empty()
-    case .tapMoreCategoryButton:
-      return .empty()
+    case .tapMoreTopButton(let title):
+      return .just(.setNavigation(.navTotop100VC(type: .normal, title: title)))
+      
+    case .tapMoreCategoryButton(let title):
+      return .just(.setNavigation(.navTotop100VC(type: .category, title: title)))
     }
   }
   
@@ -86,6 +89,8 @@ final class HotChalMainReactor: Reactor {
       newState.isLoading = isLoading
     case .setSelectedChallenge(let item):
       newState.selectedChallenge = item
+    case .setNavigation(let nav):
+      newState.navigation = nav
     }
     
     return newState

--- a/HotChal/HotChal/Scene/Chal/HotChalMainScene/HotChalMainViewController.swift
+++ b/HotChal/HotChal/Scene/Chal/HotChalMainScene/HotChalMainViewController.swift
@@ -6,15 +6,24 @@
 //
 
 import UIKit
+import RxSwift
+import RxCocoa
 
 /// HotChall - front - HotChallMainViewController
 /// 핫챌 메인 화면
 final class HotChalMainViewController: UIViewController {
   
   weak var coordinator: ChalCoordinator?
+  var reactor: HotChalMainReactor? = nil
+  private let disposeBag: DisposeBag = DisposeBag()
   
   private let mainView: HotChalMainView = HotChalMainView()
-  
+  private lazy var categoryViews: [HotChallTop3CategoryView] = [
+      mainView.top1ChallengeView,
+      mainView.top2ChallengeView,
+      mainView.top3ChallengeView
+  ]
+
   override func loadView() {
     super.loadView()
     self.view = mainView
@@ -52,14 +61,36 @@ final class HotChalMainViewController: UIViewController {
     mainView.topCollectionView.delegate = self
     mainView.topCollectionView.dataSource = self
     
-    [
-      mainView.top1ChallengeView.collectionView,
-      mainView.top2ChallengeView.collectionView,
-      mainView.top3ChallengeView.collectionView
-    ].forEach {
-      $0.delegate = self
-      $0.dataSource = self
+    categoryViews.forEach {
+      $0.collectionView.delegate = self
+      $0.collectionView.dataSource = self
     }
+  }
+  
+  private func bind(wtih reactor: HotChalMainReactor) {
+    mainView.topMoreButton.rx.tap
+      .map { HotChalMainReactor.Action.tapMoreTopButton }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+    
+    for (index, view) in categoryViews.enumerated() {
+      view.moreButton.rx.tap
+        .map { HotChalMainReactor.Action.tapMoreCategoryButton }
+        .bind(to: reactor.action)
+        .disposed(by: disposeBag)
+      
+      view.collectionView.rx.itemSelected
+        .map { HotChalMainReactor.Action.tapCategoryItem(index, $0) }
+        .bind(to: reactor.action)
+        .disposed(by: self.disposeBag)
+    }
+    
+    reactor.state.map { $0.categoryVideos }
+      .withUnretained(self)
+      .subscribe(onNext: { _ in
+        self.categoryViews.forEach { $0.collectionView.reloadData() }
+      })
+      .disposed(by: disposeBag)
   }
   
   
@@ -93,9 +124,9 @@ extension HotChalMainViewController: UICollectionViewDataSource {
 
     switch collectionView {
     case mainView.topCollectionView: return 3
-    case mainView.top1ChallengeView.collectionView: return categoryDatas[0]?.count ?? 0
-    case mainView.top2ChallengeView.collectionView: return categoryDatas[1]?.count ?? 0
-    case mainView.top3ChallengeView.collectionView: return categoryDatas[2]?.count ?? 0
+    case mainView.top1ChallengeView.collectionView: return categoryDatas[0].count
+    case mainView.top2ChallengeView.collectionView: return categoryDatas[1].count
+    case mainView.top3ChallengeView.collectionView: return categoryDatas[2].count
     default:
       return 0
     }
@@ -120,11 +151,7 @@ extension HotChalMainViewController: UICollectionViewDataSource {
     }
     
     // Top 1~3 CollectionViews 매핑
-    let collectionViews: [UICollectionView] = [
-      mainView.top1ChallengeView.collectionView,
-      mainView.top2ChallengeView.collectionView,
-      mainView.top3ChallengeView.collectionView
-    ]
+    let collectionViews: [UICollectionView] = categoryViews.map({ $0.collectionView })
     
     if let categoryIndex = collectionViews.firstIndex(of: collectionView) {
       guard let cell = collectionView.dequeueReusableCell(
@@ -132,7 +159,7 @@ extension HotChalMainViewController: UICollectionViewDataSource {
         for: indexPath
       ) as? ChallengeCell else { return UICollectionViewCell() }
       
-      cell.challengeData = categoryDatas[categoryIndex]?[indexPath.row]
+      cell.challengeData = categoryDatas[categoryIndex][indexPath.row]
       return cell
     }
     
@@ -153,11 +180,11 @@ extension HotChalMainViewController: UICollectionViewDelegateFlowLayout{
     case mainView.topCollectionView:
       challengeData = MockupDataManager.shared.top3ChallengeVideos[indexPath.row]
     case mainView.top1ChallengeView.collectionView:
-      challengeData = categoryDatas[0]?[indexPath.row]
+      challengeData = categoryDatas[0][indexPath.row]
     case mainView.top2ChallengeView.collectionView:
-      challengeData = categoryDatas[1]?[indexPath.row]
+      challengeData = categoryDatas[1][indexPath.row]
     case mainView.top3ChallengeView.collectionView:
-      challengeData = categoryDatas[2]?[indexPath.row]
+      challengeData = categoryDatas[2][indexPath.row]
     default:
       break
     }
@@ -186,7 +213,7 @@ extension HotChalMainViewController: UICollectionViewDelegateFlowLayout{
 }
 
 // MARK: Challenge Player Delegate
-
+// ChallengeNavigationDelegate 가 있는데 이건 또 뭐냐
 extension HotChalMainViewController: ChallengePlayerViewDelegate {
   func navToTakeChallenge(with data: ChallengeVideo) {
 

--- a/HotChal/HotChal/Scene/Chal/HotChalMainScene/HotChalMainViewController.swift
+++ b/HotChal/HotChal/Scene/Chal/HotChalMainScene/HotChalMainViewController.swift
@@ -28,17 +28,18 @@ final class HotChalMainViewController: UIViewController {
     super.loadView()
     self.view = mainView
   }
-  
-  /// viewDidLoad
+
+  // MARK: viewDidLoad
+
   override func viewDidLoad() {
     super.viewDidLoad()
     
     self.title = "핫챌 Top3"
 
     setupMainViewCell()
-    addButtonActions()
     
     mainView.scrollView.delegate = self
+    bind(wtih: reactor ?? HotChalMainReactor())
   }
   
   override func viewWillAppear(_ animated: Bool) {
@@ -57,145 +58,85 @@ final class HotChalMainViewController: UIViewController {
   
   /// 셀 delegate 및 dataSource 설정
   private func setupMainViewCell() {
-    
     mainView.topCollectionView.delegate = self
-    mainView.topCollectionView.dataSource = self
-    
-    categoryViews.forEach {
-      $0.collectionView.delegate = self
-      $0.collectionView.dataSource = self
-    }
+    categoryViews.forEach { $0.collectionView.delegate = self }
   }
   
+  // MARK: bind
+
   private func bind(wtih reactor: HotChalMainReactor) {
+    // 초기 데이터
+    Observable.just(())
+      .map { HotChalMainReactor.Action.setupInititalDatas }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+    
+    // action
+    mainView.topCollectionView.rx.itemSelected
+      .map { HotChalMainReactor.Action.tapTopItem($0.row) }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+    
     mainView.topMoreButton.rx.tap
-      .map { HotChalMainReactor.Action.tapMoreTopButton }
+      .map { HotChalMainReactor.Action.tapMoreTopButton("핫챌 Top20") }
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
     
     for (index, view) in categoryViews.enumerated() {
       view.moreButton.rx.tap
-        .map { HotChalMainReactor.Action.tapMoreCategoryButton }
+        .map { HotChalMainReactor.Action.tapMoreCategoryButton(view.titleLabel.text ?? "") }
         .bind(to: reactor.action)
         .disposed(by: disposeBag)
       
       view.collectionView.rx.itemSelected
-        .map { HotChalMainReactor.Action.tapCategoryItem(index, $0) }
+        .map { HotChalMainReactor.Action.tapCategoryItem(categoryIndex: index, itemIndex: $0.row) }
         .bind(to: reactor.action)
-        .disposed(by: self.disposeBag)
+        .disposed(by: disposeBag)
     }
     
-    reactor.state.map { $0.categoryVideos }
+    // state
+    reactor.state.map { $0.top3Challenge }
+      .bind(to: mainView.topCollectionView.rx.items(
+        cellIdentifier: HotChallTopCell.reuseIdentifier,
+        cellType: HotChallTopCell.self)) { row, product, cell in
+          cell.challengeData = (product, row)
+        }
+        .disposed(by: disposeBag)
+
+    for (index, view) in categoryViews.enumerated() {
+      reactor.state.map { $0.categoryVideos[index] }
+        .bind(to: view.collectionView.rx.items(
+          cellIdentifier: ChallengeCell.reuseIdentifier,
+          cellType: ChallengeCell.self)) { _ , video, cell in
+            cell.challengeData = video
+          }
+          .disposed(by: self.disposeBag)
+    }
+    
+    reactor.state.map { $0.navigation }
+      .distinctUntilChanged()
+      .compactMap { $0 }
       .withUnretained(self)
-      .subscribe(onNext: { _ in
-        self.categoryViews.forEach { $0.collectionView.reloadData() }
+      .subscribe(onNext: { (_, event) in
+          switch event {
+          case let .navTotop100VC(type, title):
+              self.coordinator?.navToHotChallTop100ViewController(type: type, title: title)
+          }
       })
       .disposed(by: disposeBag)
-  }
-  
-  
-  /// 버튼 액션 추가하기
-  private func addButtonActions(){
-    mainView.topMoreButton.addAction(UIAction { [weak self] _ in
-      self?.coordinator?.navToHotChallTop100ViewController()
-    } , for: .touchUpInside)
-    
-    // 카테고리 별 전체보기 버튼을 찾아서 버튼 액션 달아주기
-    [
-      mainView.top1ChallengeView,
-      mainView.top2ChallengeView,
-      mainView.top3ChallengeView
-    ].forEach {
-      guard let challengeName = $0.titleLabel.text else { return }
-      
-      $0.moreButton.addAction(UIAction { [weak self] _ in
-        self?.coordinator?.navToHotChallTop100ViewController(type: .category, title: challengeName)
-      }, for: .touchUpInside)
-    }
-  }
-}
 
-// MARK: - UICollectionViewDataSource
-
-extension HotChalMainViewController: UICollectionViewDataSource {
-  
-  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    let categoryDatas = MockupDataManager.shared.top3ChallengeVideosWithCategory
-
-    switch collectionView {
-    case mainView.topCollectionView: return 3
-    case mainView.top1ChallengeView.collectionView: return categoryDatas[0].count
-    case mainView.top2ChallengeView.collectionView: return categoryDatas[1].count
-    case mainView.top3ChallengeView.collectionView: return categoryDatas[2].count
-    default:
-      return 0
-    }
-  }
-  
-  func collectionView(
-    _ collectionView: UICollectionView,
-    cellForItemAt indexPath: IndexPath
-  ) -> UICollectionViewCell {
-    let categoryDatas = MockupDataManager.shared.top3ChallengeVideosWithCategory
-    
-    // Top CollectionView
-    if collectionView == mainView.topCollectionView {
-      guard let cell = collectionView.dequeueReusableCell(
-        withReuseIdentifier: HotChallTopCell.reuseIdentifier,
-        for: indexPath
-      ) as? HotChallTopCell else { return UICollectionViewCell() }
-      
-      cell.challengeData = (MockupDataManager.shared.top3ChallengeVideos[indexPath.item], indexPath.item)
-      
-      return cell
-    }
-    
-    // Top 1~3 CollectionViews 매핑
-    let collectionViews: [UICollectionView] = categoryViews.map({ $0.collectionView })
-    
-    if let categoryIndex = collectionViews.firstIndex(of: collectionView) {
-      guard let cell = collectionView.dequeueReusableCell(
-        withReuseIdentifier: ChallengeCell.reuseIdentifier,
-        for: indexPath
-      ) as? ChallengeCell else { return UICollectionViewCell() }
-      
-      cell.challengeData = categoryDatas[categoryIndex][indexPath.row]
-      return cell
-    }
-    
-    return UICollectionViewCell()
+    reactor.state.compactMap { $0.selectedChallenge }
+      .withUnretained(self)
+      .subscribe(onNext: { _, video in
+        self.coordinator?.showChallPlayer(from: self, data: video)
+      })
+      .disposed(by: disposeBag)
   }
 }
 
 // MARK: CollectionView DelegateFlowLayout
 
 extension HotChalMainViewController: UICollectionViewDelegateFlowLayout{
-  
-  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    var challengeData: ChallengeVideo?
-    
-    let categoryDatas = MockupDataManager.shared.top3ChallengeVideosWithCategory
-    
-    switch collectionView {
-    case mainView.topCollectionView:
-      challengeData = MockupDataManager.shared.top3ChallengeVideos[indexPath.row]
-    case mainView.top1ChallengeView.collectionView:
-      challengeData = categoryDatas[0][indexPath.row]
-    case mainView.top2ChallengeView.collectionView:
-      challengeData = categoryDatas[1][indexPath.row]
-    case mainView.top3ChallengeView.collectionView:
-      challengeData = categoryDatas[2][indexPath.row]
-    default:
-      break
-    }
-    
-    if let data = challengeData {
-//      ChallengePlayerUIManager.shared.showChallPlayer(from: self, data: data)
-      coordinator?.showChallPlayer(from: self, data: data)
-    }
-  }
-
-  
   func collectionView(
     _ collectionView: UICollectionView,
     layout collectionViewLayout: UICollectionViewLayout,
@@ -229,7 +170,6 @@ extension HotChalMainViewController: ChallengePlayerViewDelegate {
   
   func navToShowChallenge(with data: ChallengeVideo) {
     guard let challenge = data.videoFilename else { return }
-    //    ChallengePlayerManager.shared.playLocalVideo(named: challenge, from: self)
     coordinator?.navToShowChallengeViewController(with: challenge)
   }
   

--- a/HotChal/HotChal/Scene/Learn/Coordinator/HotChallLearnCoordinator.swift
+++ b/HotChal/HotChal/Scene/Learn/Coordinator/HotChallLearnCoordinator.swift
@@ -21,14 +21,16 @@ final class HotChallLearnCoordinator: ChallengePlayerCoordinator {
     
   }
     
+  #warning("중복되는거 같은데 확인필요")
     func navToTakeChallengeViewController(audioFileName: String, subVideoFilename: String?) {
         lastSubVideoFilename = subVideoFilename
-        let cameraCoordinator = CameraCoordinator(navigationController: navigationController,
-                                                  audioFileName: audioFileName)
-        cameraCoordinator.delegate = self
-        cameraCoordinator.finishDelegate = self
-        childCoordinators.append(cameraCoordinator)
-        cameraCoordinator.start()
+        super.navToTakeChallengeViewController(audioFileName: audioFileName)
+//        let cameraCoordinator = CameraCoordinator(navigationController: navigationController,
+//                                                  audioFileName: audioFileName)
+//        cameraCoordinator.delegate = self
+//        cameraCoordinator.finishDelegate = self
+//        childCoordinators.append(cameraCoordinator)
+//        cameraCoordinator.start()
       }
 
       // (하위호환) 1-파라미터

--- a/HotChal/HotChal/Scene/SavedChallenge/SavedHotChallViewController.swift
+++ b/HotChal/HotChal/Scene/SavedChallenge/SavedHotChallViewController.swift
@@ -223,7 +223,8 @@ extension SavedHotChallViewController: ChallengeHeaderViewActionDelegate{
 }
 
 ///  MARK: Challenge Player Delegate
-
+#warning("중복확인필요")
+ // ChallengeNavigationDelegate
 extension SavedHotChallViewController: ChallengePlayerViewDelegate {
   func navToTakeChallenge(with data: ChallengeVideo) {
 


### PR DESCRIPTION
Related Issues
---

- [ #3 ] 

---
## 🔧 작업 내용

### 1. HotChalMainViewController의 입력 이벤트를 Reactor Action으로 전환

* Top3 챌린지 셀 선택 → `.tapTopItem`
* Top20 더보기 버튼 → `.tapMoreTopButton`
* 카테고리별 더보기 버튼 → `.tapMoreCategoryButton`
* 카테고리별 셀 선택 → `.tapCategoryItem`

### 2. Reactor의 State를 화면 UI와 바인딩

* `state.top3Challenge` → Top CollectionView에 바인딩
* `state.categoryVideos` → 카테고리 CollectionView에 바인딩
* `state.selectedChallenge` → 챌린지 플레이어 화면 이동
* `state.navigation` → Top100 화면 이동
---

## 📁 변경된 파일

* `HotChalMainViewController.swift`
* `HotChalMainReactor.swift`
---

## 🧪 테스트 체크리스트

* [ ✅] Top3 챌린지 셀 탭 시 플레이어 정상 재생
* [ ✅ ] Top3 더보기 버튼 클릭 시 Top100 화면 이동
* [ ✅ ] 카테고리별 더보기 버튼 정상 동작
* [ ✅ ] 카테고리 CollectionView 바인딩 정상 갱신
* [ ✅ ] state 변경에 따라 UI 자동 갱신되는지 확인
* [ ✅ ] 화면 스크롤 시 플레이어 자동 닫힘 정상 동작

