### PR TITLE
[Refactor]coordinator

### DIFF
--- a/HotChal/HotChal/Coordinator/BaseCoordinator.swift
+++ b/HotChal/HotChal/Coordinator/BaseCoordinator.swift
@@ -24,25 +24,12 @@ class BaseCoordinator: Coordinator {
     func finish() {
         finishDelegate?.coordinatorDidFinish(childCoordinator: self)
     }
-    
-    func didFinishCameraRecording(url: URL) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            let vc = ChallCompareViewController()
-            vc.videoURL = url
-            // ChalCoordinator에서만 coordinator 참조를 달아줘야 하면 아래 캐스팅 유지
-            if let chal = self as? ChalCoordinator {
-                vc.coordinator = chal
-            }
-            self.navigationController.pushViewController(vc, animated: true)
-        }
-    }
 }
 
-extension BaseCoordinator: ChallengeNavigationDelegate {
+extension BaseCoordinator {
   func cameraCoordinatorDidFinishWithVideo(url: URL) {
 //    navToCompareViewController(url: url)
-      didFinishCameraRecording(url: url)
+//      didFinishCameraRecording(url: url)
   }
   
   func coordinatorDidFinish(childCoordinator: any Coordinator) {

--- a/HotChal/HotChal/Coordinator/ChallengePlayerCoordinator.swift
+++ b/HotChal/HotChal/Coordinator/ChallengePlayerCoordinator.swift
@@ -8,11 +8,8 @@
 import UIKit
 
 /// 플레이어 매니저
-class ChallengePlayerCoordinator: BaseCoordinator, GetKeyWindowProtocol {
-  // 여기서 플레이어뷰의 이동 델리게이트를 처리하는게 맞는듯
-  // 문제 : 플레이어 프로토콜이 2개임 ChallengeNavigationDelegate, ChallengePlayerViewDelegate
-  // 하나로 합치고 여기에서 playerview로 델리게이트를 넣어주고 extension으로 빼서 공통된 화면이동을 처리하기
-  // 챌린지플레이어 코디네이터라는 클래스의 의미에도 맞을듯
+class ChallengePlayerCoordinator: BaseCoordinator, GetKeyWindowProtocol, ChallengeNavigationDelegate {
+  
   private weak var playerView: ChallPlayerView?
   
   /// 플레이어 UI 보여주기

--- a/HotChal/HotChal/Coordinator/ChallengePlayerCoordinator.swift
+++ b/HotChal/HotChal/Coordinator/ChallengePlayerCoordinator.swift
@@ -8,9 +8,11 @@
 import UIKit
 
 /// 플레이어 매니저
-class ChallengePlayerCoordinator: BaseCoordinator,
-                                  GetKeyWindowProtocol {
-  
+class ChallengePlayerCoordinator: BaseCoordinator, GetKeyWindowProtocol {
+  // 여기서 플레이어뷰의 이동 델리게이트를 처리하는게 맞는듯
+  // 문제 : 플레이어 프로토콜이 2개임 ChallengeNavigationDelegate, ChallengePlayerViewDelegate
+  // 하나로 합치고 여기에서 playerview로 델리게이트를 넣어주고 extension으로 빼서 공통된 화면이동을 처리하기
+  // 챌린지플레이어 코디네이터라는 클래스의 의미에도 맞을듯
   private weak var playerView: ChallPlayerView?
   
   /// 플레이어 UI 보여주기

--- a/HotChal/HotChal/Coordinator/Protocol/ChallengeNavigationProtocol.swift
+++ b/HotChal/HotChal/Coordinator/Protocol/ChallengeNavigationProtocol.swift
@@ -8,51 +8,50 @@
 import Foundation
 
 /// 챌린지 관련 화면이동 Delegate
-/// 챌린지 찍기, 보기, 배우기
-
+/// - 챌린지 찍기, 보기, 배우기
+/// - Coordinator로 화면 이동을 처리하기 위한 전용 delegate
 protocol ChallengeNavigationDelegate: AnyObject, CameraCoordinatorDelegate, CoordinatorFinishDelegate {
-    func navToLearnChallengeViewController(with challenge: ChallengeVideo)
-    func navToShowChallengeViewController(with challenge: String)
-    func navToTakeChallengeViewController(audioFileName: String)
-    func navToTakeChallengeViewController(audioFileName: String, subVideoFilename: String?)
+  func navToLearnChallengeViewController(with challenge: ChallengeVideo)
+  func navToShowChallengeViewController(with challenge: String)
+  func navToTakeChallengeViewController(audioFileName: String)
+  func navToTakeChallengeViewController(audioFileName: String, subVideoFilename: String?)
 }
 
 extension ChallengeNavigationDelegate where Self: BaseCoordinator {
-    func navToTakeChallengeViewController(audioFileName: String) {
-      let cameraCoordinator = CameraCoordinator(
-        navigationController: navigationController,
-        audioFileName: audioFileName
-      )
-      cameraCoordinator.delegate = self
-      cameraCoordinator.finishDelegate = self
-      childCoordinators.append(cameraCoordinator)
-      cameraCoordinator.start()
+  func navToTakeChallengeViewController(audioFileName: String) {
+    let cameraCoordinator = CameraCoordinator(
+      navigationController: navigationController,
+      audioFileName: audioFileName
+    )
+    cameraCoordinator.delegate = self
+    cameraCoordinator.finishDelegate = self
+    childCoordinators.append(cameraCoordinator)
+    cameraCoordinator.start()
   }
   
-    
-    func navToTakeChallengeViewController() {
-      navToTakeChallengeViewController(audioFileName: "")
-    }
-    
-    func navToTakeChallengeViewController(audioFileName: String, subVideoFilename: String?) {
-        navToTakeChallengeViewController(audioFileName: audioFileName)
-    }
-
-    
-    func navToLearnChallengeViewController(with challenge: ChallengeVideo){
-        let vc = PlayerViewController()
-        vc.challengeData = challenge
-        vc.hidesBottomBarWhenPushed = true
-        self.navigationController.pushViewController(vc, animated: true)
-    }
-    
-    func navToShowChallengeViewController(with challenge: String) {
-        let vc = ShowChallengePageViewController(
-            transitionStyle: .scroll,
-            navigationOrientation: .vertical
-        )
-        vc.coordinatorDelgate = self
-        vc.selectedVideo = challenge
-        navigationController.pushViewController(vc, animated: true)
-    }
+  func navToTakeChallengeViewController() {
+    navToTakeChallengeViewController(audioFileName: "")
+  }
+  
+  func navToTakeChallengeViewController(audioFileName: String, subVideoFilename: String?) {
+    navToTakeChallengeViewController(audioFileName: audioFileName)
+  }
+  
+  func navToLearnChallengeViewController(with challenge: ChallengeVideo){
+    let vc = PlayerViewController()
+    vc.challengeData = challenge
+    vc.coordinator = self
+    vc.hidesBottomBarWhenPushed = true
+    self.navigationController.pushViewController(vc, animated: true)
+  }
+  
+  func navToShowChallengeViewController(with challenge: String) {
+    let vc = ShowChallengePageViewController(
+      transitionStyle: .scroll,
+      navigationOrientation: .vertical
+    )
+    vc.coordinatorDelgate = self
+    vc.selectedVideo = challenge
+    navigationController.pushViewController(vc, animated: true)
+  }
 }

--- a/HotChal/HotChal/DesignSytem/Soruces/Components/CustomView/ChallPlayerView.swift
+++ b/HotChal/HotChal/DesignSytem/Soruces/Components/CustomView/ChallPlayerView.swift
@@ -7,27 +7,10 @@
 
 import UIKit
 
-
-/// 플레이어 액션 Delegate
-protocol ChallengePlayerViewDelegate: AnyObject {
-  func navToLearnChallenge(with data: ChallengeVideo)
-  func navToShowChallenge(with data: ChallengeVideo)
-  func navToTakeChallenge(with data: ChallengeVideo)
-  func saveChallenge(with data: ChallengeVideo)
-  //  func closePlayerUI()
-}
-//
-//extension ChallengePlayerViewDelegate {
-//  func closePlayerUI(){
-//    ChallengePlayerUIManager.shared.closeChallPlayer()
-//  }
-//}
-
 /// 챌린지 영상 플레이어 UIView
 final class ChallPlayerView: UIView {
   
   weak var delegate: ChallengePlayerViewDelegate?
-  
   var challengeData: ChallengeVideo
   
   /// 챌린지 배우기 버튼
@@ -115,12 +98,10 @@ final class ChallPlayerView: UIView {
   
   /// 버튼의 액션 설정
   private func setupButtonActions(){
-    
     learnChallengeButton.addAction(UIAction { [weak self] _ in
       guard let self = self else { return }
       self.closeChallPlayer()
       self.delegate?.navToLearnChallenge(with: challengeData)
-      
     }, for: .touchUpInside)
     
     saveChallengeButton.addAction(UIAction { [weak self] _ in

--- a/HotChal/HotChal/Protocols/ChallengePlayerProtocol.swift
+++ b/HotChal/HotChal/Protocols/ChallengePlayerProtocol.swift
@@ -1,0 +1,44 @@
+//
+//  ChallengePlayerProtocol.swift
+//  HotChal
+//
+//  Created by 최용헌 on 11/20/25.
+//
+
+import UIKit
+
+/// 플레이어 액션 Delegate
+/// - 플레이어 화면 내부의 사용자 인터랙션 처리
+protocol ChallengePlayerViewDelegate: AnyObject {
+  var challengeNavigationDelegate: ChallengeNavigationDelegate? { get }
+  
+  func navToLearnChallenge(with data: ChallengeVideo)
+  func navToShowChallenge(with data: ChallengeVideo)
+  func navToTakeChallenge(with data: ChallengeVideo)
+  func saveChallenge(with data: ChallengeVideo)
+}
+
+extension ChallengePlayerViewDelegate where Self: UIViewController {
+  func navToLearnChallenge(with data: ChallengeVideo) {
+    challengeNavigationDelegate?.navToLearnChallengeViewController(with: data)
+  }
+  
+  func navToShowChallenge(with data: ChallengeVideo) {
+    guard let challenge = data.videoFilename else { return }
+    challengeNavigationDelegate?.navToShowChallengeViewController(with: challenge)
+  }
+  
+  func navToTakeChallenge(with data: ChallengeVideo) {
+    challengeNavigationDelegate?.navToTakeChallengeViewController(
+      audioFileName: data.videoFilename ?? "",
+      subVideoFilename: data.videoFilename
+    )
+  }
+  
+  func saveChallenge(with data: ChallengeVideo) {
+    CoreDataManager.shared.saveChallenge(with: data) { result in
+      let comment = result ? "챌린지가 저장되었습니다." : "이미 저장된 챌린지입니다."
+      ToastPopupManager.shared.showToast(message: comment, from: self)
+    }
+  }
+}

--- a/HotChal/HotChal/Scene/Chal/Coordinator/ChalCoordinator.swift
+++ b/HotChal/HotChal/Scene/Chal/Coordinator/ChalCoordinator.swift
@@ -28,44 +28,44 @@ final class ChalCoordinator: ChallengePlayerCoordinator {
     self.navigationController.pushViewController(vc, animated: true)
   }
   
-  /// 챌린지 배우기 디테일 화면으로 이동
-  func navToLearnChallengeViewController(with data: ChallengeVideo) {
-    let vc = PlayerViewController()
-    vc.challengeData = data
-    vc.hidesBottomBarWhenPushed = true
-    vc.coordinator = self
-    self.navigationController.pushViewController(vc, animated: true)
-  }
-  
-  // 챌린지 찍기 화면으로 이동
-  // 이게 지금 lastSubVideo에 넣는 걸 코디네이터에서 하면 안되지
-  func navToTakeChallengeViewController(
-    audioFileName: String,
-    subVideoFilename: String?
-  ) {
-    lastSubVideoFilename = subVideoFilename
-    super.navToTakeChallengeViewController(audioFileName: audioFileName)
-    
-//    let cameraCoordinator = CameraCoordinator(navigationController: navigationController,
-//                                              audioFileName: audioFileName)
-//    cameraCoordinator.delegate = self
-//    cameraCoordinator.finishDelegate = self
-//    childCoordinators.append(cameraCoordinator)
-//    cameraCoordinator.start()
-  }
-  
-  
-  /// 찍은 챌린지 비교해보기 화면으로 이동
-  func navToCompareViewController(url: URL) {
-    let vc = ChallCompareViewController()
-    vc.videoURL = url
-    vc.subVideoFilename = lastSubVideoFilename
-    vc.coordinator = self
-    vc.hidesBottomBarWhenPushed = true
-    navigationController.pushViewController(vc, animated: true)
-  }
-  
-  override func didFinishCameraRecording(url: URL) {
-    self.navToCompareViewController(url: url)
-  }
+//  /// 챌린지 배우기 디테일 화면으로 이동
+//  func navToLearnChallengeViewController(with data: ChallengeVideo) {
+//    let vc = PlayerViewController()
+//    vc.challengeData = data
+//    vc.hidesBottomBarWhenPushed = true
+//    vc.coordinator = self
+//    self.navigationController.pushViewController(vc, animated: true)
+//  }
+//  
+//  // 챌린지 찍기 화면으로 이동
+//  // 이게 지금 lastSubVideo에 넣는 걸 코디네이터에서 하면 안되지
+//  func navToTakeChallengeViewController(
+//    audioFileName: String,
+//    subVideoFilename: String?
+//  ) {
+//    lastSubVideoFilename = subVideoFilename
+//    super.navToTakeChallengeViewController(audioFileName: audioFileName)
+//    
+////    let cameraCoordinator = CameraCoordinator(navigationController: navigationController,
+////                                              audioFileName: audioFileName)
+////    cameraCoordinator.delegate = self
+////    cameraCoordinator.finishDelegate = self
+////    childCoordinators.append(cameraCoordinator)
+////    cameraCoordinator.start()
+//  }
+//  
+//  
+//  /// 찍은 챌린지 비교해보기 화면으로 이동
+//  func navToCompareViewController(url: URL) {
+//    let vc = ChallCompareViewController()
+//    vc.videoURL = url
+//    vc.subVideoFilename = lastSubVideoFilename
+//    vc.coordinator = self
+//    vc.hidesBottomBarWhenPushed = true
+//    navigationController.pushViewController(vc, animated: true)
+//  }
+//  
+//  override func didFinishCameraRecording(url: URL) {
+//    self.navToCompareViewController(url: url)
+//  }
 }

--- a/HotChal/HotChal/Scene/Chal/Coordinator/ChalCoordinator.swift
+++ b/HotChal/HotChal/Scene/Chal/Coordinator/ChalCoordinator.swift
@@ -10,8 +10,6 @@ enum HotChalMainNavigationEvent: Equatable {
 /// 핫첼 메인화면이동 코디네이터
 final class ChalCoordinator: ChallengePlayerCoordinator {
   
-  private var lastSubVideoFilename: String?
-  
   override func start() {
     let chalMainViewController = HotChalMainViewController()
     chalMainViewController.coordinator = self
@@ -27,45 +25,4 @@ final class ChalCoordinator: ChallengePlayerCoordinator {
     vc.coordinator = self
     self.navigationController.pushViewController(vc, animated: true)
   }
-  
-//  /// 챌린지 배우기 디테일 화면으로 이동
-//  func navToLearnChallengeViewController(with data: ChallengeVideo) {
-//    let vc = PlayerViewController()
-//    vc.challengeData = data
-//    vc.hidesBottomBarWhenPushed = true
-//    vc.coordinator = self
-//    self.navigationController.pushViewController(vc, animated: true)
-//  }
-//  
-//  // 챌린지 찍기 화면으로 이동
-//  // 이게 지금 lastSubVideo에 넣는 걸 코디네이터에서 하면 안되지
-//  func navToTakeChallengeViewController(
-//    audioFileName: String,
-//    subVideoFilename: String?
-//  ) {
-//    lastSubVideoFilename = subVideoFilename
-//    super.navToTakeChallengeViewController(audioFileName: audioFileName)
-//    
-////    let cameraCoordinator = CameraCoordinator(navigationController: navigationController,
-////                                              audioFileName: audioFileName)
-////    cameraCoordinator.delegate = self
-////    cameraCoordinator.finishDelegate = self
-////    childCoordinators.append(cameraCoordinator)
-////    cameraCoordinator.start()
-//  }
-//  
-//  
-//  /// 찍은 챌린지 비교해보기 화면으로 이동
-//  func navToCompareViewController(url: URL) {
-//    let vc = ChallCompareViewController()
-//    vc.videoURL = url
-//    vc.subVideoFilename = lastSubVideoFilename
-//    vc.coordinator = self
-//    vc.hidesBottomBarWhenPushed = true
-//    navigationController.pushViewController(vc, animated: true)
-//  }
-//  
-//  override func didFinishCameraRecording(url: URL) {
-//    self.navToCompareViewController(url: url)
-//  }
 }

--- a/HotChal/HotChal/Scene/Chal/Features/HotChallTop100ViewController.swift
+++ b/HotChal/HotChal/Scene/Chal/Features/HotChallTop100ViewController.swift
@@ -127,12 +127,8 @@ extension HotChallTop100ViewController: UICollectionViewDelegateFlowLayout{
     didSelectItemAt indexPath: IndexPath
   ) {
     let challengeData: ChallengeVideo = challengeDatas[indexPath.item]
-    
     coordinator?.showChallPlayer(from: self, data: challengeData)
-    
-
-//    delegate?.showcha(from: self, data: challengeData)
-  }
+    }
   
   func collectionView(
     _ collectionView: UICollectionView,
@@ -149,30 +145,6 @@ extension HotChallTop100ViewController: UICollectionViewDelegateFlowLayout{
 
 // MARK: Challenge Player Delegate
 
-//extension HotChallTop100ViewController: ChallengePlayerViewDelegate {
-//    func navToTakeChallenge(with data: ChallengeVideo) {
-//
-//        let audioName = data.mp4FilenameWithoutExtension ?? (data.videoFilename ?? "")
-//        coordinator?.navToTakeChallengeViewController(
-//            audioFileName: audioName,
-//            subVideoFilename: data.videoFilename
-//        )
-//    }
-//  
-//  func navToLearnChallenge(with data: ChallengeVideo) {
-//    coordinator?.navToLearnChallengeViewController(with: data)
-//  }
-//  
-//  func navToShowChallenge(with data: ChallengeVideo) {
-//    guard let challenge = data.videoFilename else { return }
-//    coordinator?.navToShowChallengeViewController(with: challenge)
-//  }
-//  
-//  func saveChallenge(with data: ChallengeVideo) {
-//    CoreDataManager.shared.saveChallenge(with: data) { result in
-//      let comment = result ? "챌린지가 저장되었습니다." : "이미 저장된 챌린지입니다."
-//      
-//      ToastPopupManager.shared.showToast(message: comment, from: self)
-//    }
-//  }
-//}
+extension HotChallTop100ViewController: ChallengePlayerViewDelegate {
+  var challengeNavigationDelegate: ChallengeNavigationDelegate? { coordinator }
+}

--- a/HotChal/HotChal/Scene/Chal/Features/HotChallTop100ViewController.swift
+++ b/HotChal/HotChal/Scene/Chal/Features/HotChallTop100ViewController.swift
@@ -149,30 +149,30 @@ extension HotChallTop100ViewController: UICollectionViewDelegateFlowLayout{
 
 // MARK: Challenge Player Delegate
 
-extension HotChallTop100ViewController: ChallengePlayerViewDelegate {
-    func navToTakeChallenge(with data: ChallengeVideo) {
-
-        let audioName = data.mp4FilenameWithoutExtension ?? (data.videoFilename ?? "")
-        coordinator?.navToTakeChallengeViewController(
-            audioFileName: audioName,
-            subVideoFilename: data.videoFilename
-        )
-    }
-  
-  func navToLearnChallenge(with data: ChallengeVideo) {
-    coordinator?.navToLearnChallengeViewController(with: data)
-  }
-  
-  func navToShowChallenge(with data: ChallengeVideo) {
-    guard let challenge = data.videoFilename else { return }
-    coordinator?.navToShowChallengeViewController(with: challenge)
-  }
-  
-  func saveChallenge(with data: ChallengeVideo) {
-    CoreDataManager.shared.saveChallenge(with: data) { result in
-      let comment = result ? "챌린지가 저장되었습니다." : "이미 저장된 챌린지입니다."
-      
-      ToastPopupManager.shared.showToast(message: comment, from: self)
-    }
-  }
-}
+//extension HotChallTop100ViewController: ChallengePlayerViewDelegate {
+//    func navToTakeChallenge(with data: ChallengeVideo) {
+//
+//        let audioName = data.mp4FilenameWithoutExtension ?? (data.videoFilename ?? "")
+//        coordinator?.navToTakeChallengeViewController(
+//            audioFileName: audioName,
+//            subVideoFilename: data.videoFilename
+//        )
+//    }
+//  
+//  func navToLearnChallenge(with data: ChallengeVideo) {
+//    coordinator?.navToLearnChallengeViewController(with: data)
+//  }
+//  
+//  func navToShowChallenge(with data: ChallengeVideo) {
+//    guard let challenge = data.videoFilename else { return }
+//    coordinator?.navToShowChallengeViewController(with: challenge)
+//  }
+//  
+//  func saveChallenge(with data: ChallengeVideo) {
+//    CoreDataManager.shared.saveChallenge(with: data) { result in
+//      let comment = result ? "챌린지가 저장되었습니다." : "이미 저장된 챌린지입니다."
+//      
+//      ToastPopupManager.shared.showToast(message: comment, from: self)
+//    }
+//  }
+//}

--- a/HotChal/HotChal/Scene/Chal/HotChalMainScene/HotChalMainViewController.swift
+++ b/HotChal/HotChal/Scene/Chal/HotChalMainScene/HotChalMainViewController.swift
@@ -155,30 +155,30 @@ extension HotChalMainViewController: UICollectionViewDelegateFlowLayout{
 
 // MARK: Challenge Player Delegate
 // ChallengeNavigationDelegate 가 있는데 이건 또 뭐냐
-extension HotChalMainViewController: ChallengePlayerViewDelegate {
-  func navToTakeChallenge(with data: ChallengeVideo) {
-
-    coordinator?.navToTakeChallengeViewController(
-      audioFileName: data.videoFilename ?? "",
-      subVideoFilename: data.videoFilename
-    )
-  }
-  
-  func navToLearnChallenge(with data: ChallengeVideo) {
-    coordinator?.navToLearnChallengeViewController(with: data)
-  }
-  
-  func navToShowChallenge(with data: ChallengeVideo) {
-    guard let challenge = data.videoFilename else { return }
-    coordinator?.navToShowChallengeViewController(with: challenge)
-  }
-  
-  func saveChallenge(with data: ChallengeVideo) {
-    CoreDataManager.shared.saveChallenge(with: data) { result in
-      let comment = result ? "챌린지가 저장되었습니다." : "이미 저장된 챌린지입니다."
-      
-      ToastPopupManager.shared.showToast(message: comment, from: self)
-    }
-  }
-}
-
+//extension HotChalMainViewController: ChallengePlayerViewDelegate {
+//  func navToTakeChallenge(with data: ChallengeVideo) {
+//
+//    coordinator?.navToTakeChallengeViewController(
+//      audioFileName: data.videoFilename ?? "",
+//      subVideoFilename: data.videoFilename
+//    )
+//  }
+//  
+//  func navToLearnChallenge(with data: ChallengeVideo) {
+//    coordinator?.navToLearnChallengeViewController(with: data)
+//  }
+//  
+//  func navToShowChallenge(with data: ChallengeVideo) {
+//    guard let challenge = data.videoFilename else { return }
+//    coordinator?.navToShowChallengeViewController(with: challenge)
+//  }
+//  
+//  func saveChallenge(with data: ChallengeVideo) {
+//    CoreDataManager.shared.saveChallenge(with: data) { result in
+//      let comment = result ? "챌린지가 저장되었습니다." : "이미 저장된 챌린지입니다."
+//      
+//      ToastPopupManager.shared.showToast(message: comment, from: self)
+//    }
+//  }
+//}
+//

--- a/HotChal/HotChal/Scene/Chal/HotChalMainScene/HotChalMainViewController.swift
+++ b/HotChal/HotChal/Scene/Chal/HotChalMainScene/HotChalMainViewController.swift
@@ -153,32 +153,9 @@ extension HotChalMainViewController: UICollectionViewDelegateFlowLayout{
   }
 }
 
-// MARK: Challenge Player Delegate
-// ChallengeNavigationDelegate 가 있는데 이건 또 뭐냐
-//extension HotChalMainViewController: ChallengePlayerViewDelegate {
-//  func navToTakeChallenge(with data: ChallengeVideo) {
-//
-//    coordinator?.navToTakeChallengeViewController(
-//      audioFileName: data.videoFilename ?? "",
-//      subVideoFilename: data.videoFilename
-//    )
-//  }
-//  
-//  func navToLearnChallenge(with data: ChallengeVideo) {
-//    coordinator?.navToLearnChallengeViewController(with: data)
-//  }
-//  
-//  func navToShowChallenge(with data: ChallengeVideo) {
-//    guard let challenge = data.videoFilename else { return }
-//    coordinator?.navToShowChallengeViewController(with: challenge)
-//  }
-//  
-//  func saveChallenge(with data: ChallengeVideo) {
-//    CoreDataManager.shared.saveChallenge(with: data) { result in
-//      let comment = result ? "챌린지가 저장되었습니다." : "이미 저장된 챌린지입니다."
-//      
-//      ToastPopupManager.shared.showToast(message: comment, from: self)
-//    }
-//  }
-//}
-//
+/// MARK: Challenge Player Delegate
+
+extension HotChalMainViewController: ChallengePlayerViewDelegate {
+  var challengeNavigationDelegate: ChallengeNavigationDelegate? { coordinator }
+}
+

--- a/HotChal/HotChal/Scene/Learn/Coordinator/HotChallLearnCoordinator.swift
+++ b/HotChal/HotChal/Scene/Learn/Coordinator/HotChallLearnCoordinator.swift
@@ -10,9 +10,9 @@ import UIKit
 
 /// 챌린지  배우기 코디네이터
 final class HotChallLearnCoordinator: ChallengePlayerCoordinator {
-    
-    private var lastSubVideoFilename: String?
-
+  
+  private var lastSubVideoFilename: String?
+  
   override func start() {
     let HotChallLearnViewController = HotChallLearnViewController()
     HotChallLearnViewController.coordinator = self
@@ -20,35 +20,4 @@ final class HotChallLearnCoordinator: ChallengePlayerCoordinator {
     self.navigationController.viewControllers = [HotChallLearnViewController]
     
   }
-    
-  #warning("중복되는거 같은데 확인필요")
-//    func navToTakeChallengeViewController(audioFileName: String, subVideoFilename: String?) {
-//        lastSubVideoFilename = subVideoFilename
-//        super.navToTakeChallengeViewController(audioFileName: audioFileName)
-////        let cameraCoordinator = CameraCoordinator(navigationController: navigationController,
-////                                                  audioFileName: audioFileName)
-////        cameraCoordinator.delegate = self
-////        cameraCoordinator.finishDelegate = self
-////        childCoordinators.append(cameraCoordinator)
-////        cameraCoordinator.start()
-//      }
-//
-//      // (하위호환) 1-파라미터
-//      func navToTakeChallengeViewController(audioFileName: String) {
-//        navToTakeChallengeViewController(audioFileName: audioFileName, subVideoFilename: nil)
-//      }
-//
-//      // 촬영 후 비교화면으로 이동
-//      func navToCompareViewController(url: URL) {
-//        let vc = ChallCompareViewController()
-//        vc.videoURL = url
-//        vc.subVideoFilename = lastSubVideoFilename // ✅ 핵심
-//        vc.coordinator = self
-//        vc.hidesBottomBarWhenPushed = true
-//        navigationController.pushViewController(vc, animated: true)
-//      }
-//
-////      override func didFinishCameraRecording(url: URL) {
-////        navToCompareViewController(url: url)
-////      }
-    }
+}

--- a/HotChal/HotChal/Scene/Learn/Coordinator/HotChallLearnCoordinator.swift
+++ b/HotChal/HotChal/Scene/Learn/Coordinator/HotChallLearnCoordinator.swift
@@ -22,33 +22,33 @@ final class HotChallLearnCoordinator: ChallengePlayerCoordinator {
   }
     
   #warning("중복되는거 같은데 확인필요")
-    func navToTakeChallengeViewController(audioFileName: String, subVideoFilename: String?) {
-        lastSubVideoFilename = subVideoFilename
-        super.navToTakeChallengeViewController(audioFileName: audioFileName)
-//        let cameraCoordinator = CameraCoordinator(navigationController: navigationController,
-//                                                  audioFileName: audioFileName)
-//        cameraCoordinator.delegate = self
-//        cameraCoordinator.finishDelegate = self
-//        childCoordinators.append(cameraCoordinator)
-//        cameraCoordinator.start()
-      }
-
-      // (하위호환) 1-파라미터
-      func navToTakeChallengeViewController(audioFileName: String) {
-        navToTakeChallengeViewController(audioFileName: audioFileName, subVideoFilename: nil)
-      }
-
-      // 촬영 후 비교화면으로 이동
-      func navToCompareViewController(url: URL) {
-        let vc = ChallCompareViewController()
-        vc.videoURL = url
-        vc.subVideoFilename = lastSubVideoFilename // ✅ 핵심
-        vc.coordinator = self
-        vc.hidesBottomBarWhenPushed = true
-        navigationController.pushViewController(vc, animated: true)
-      }
-
-      override func didFinishCameraRecording(url: URL) {
-        navToCompareViewController(url: url)
-      }
+//    func navToTakeChallengeViewController(audioFileName: String, subVideoFilename: String?) {
+//        lastSubVideoFilename = subVideoFilename
+//        super.navToTakeChallengeViewController(audioFileName: audioFileName)
+////        let cameraCoordinator = CameraCoordinator(navigationController: navigationController,
+////                                                  audioFileName: audioFileName)
+////        cameraCoordinator.delegate = self
+////        cameraCoordinator.finishDelegate = self
+////        childCoordinators.append(cameraCoordinator)
+////        cameraCoordinator.start()
+//      }
+//
+//      // (하위호환) 1-파라미터
+//      func navToTakeChallengeViewController(audioFileName: String) {
+//        navToTakeChallengeViewController(audioFileName: audioFileName, subVideoFilename: nil)
+//      }
+//
+//      // 촬영 후 비교화면으로 이동
+//      func navToCompareViewController(url: URL) {
+//        let vc = ChallCompareViewController()
+//        vc.videoURL = url
+//        vc.subVideoFilename = lastSubVideoFilename // ✅ 핵심
+//        vc.coordinator = self
+//        vc.hidesBottomBarWhenPushed = true
+//        navigationController.pushViewController(vc, animated: true)
+//      }
+//
+////      override func didFinishCameraRecording(url: URL) {
+////        navToCompareViewController(url: url)
+////      }
     }

--- a/HotChal/HotChal/Scene/Learn/HotChallLearnViewController.swift
+++ b/HotChal/HotChal/Scene/Learn/HotChallLearnViewController.swift
@@ -199,31 +199,10 @@ extension HotChallLearnViewController: UICollectionViewDelegateFlowLayout{
 
 // MARK: Challenge Player Delegate
 
-//extension HotChallLearnViewController: ChallengePlayerViewDelegate {
-//  func navToTakeChallenge(with data: ChallengeVideo) {
-//    coordinator?.navToTakeChallengeViewController(
-//      audioFileName: data.mp4FilenameWithoutExtension ?? "",
-//      subVideoFilename: data.videoFilename
-//    )
-//  }
-//  
-//  func navToLearnChallenge(with data: ChallengeVideo) {
-//    coordinator?.navToLearnChallengeViewController(with: data)
-//  }
-//  
-//  func navToShowChallenge(with data: ChallengeVideo) {
-//    guard let challenge = data.videoFilename else { return }
-//    coordinator?.navToShowChallengeViewController(with: challenge)
-//  }
-//  
-//  func saveChallenge(with data: ChallengeVideo) {
-//    CoreDataManager.shared.saveChallenge(with: data) { result in
-//      
-//      let comment = result ? "챌린지가 저장되었습니다." : "이미 저장된 챌린지입니다."
-//      ToastPopupManager.shared.showToast(message: comment, from: self)
-//    }
-//  }
-//}
+extension HotChallLearnViewController: ChallengePlayerViewDelegate {
+  var challengeNavigationDelegate: ChallengeNavigationDelegate? { coordinator }
+}
+
 
 // MARK: SearchBar Delegate
 

--- a/HotChal/HotChal/Scene/Learn/HotChallLearnViewController.swift
+++ b/HotChal/HotChal/Scene/Learn/HotChallLearnViewController.swift
@@ -199,31 +199,31 @@ extension HotChallLearnViewController: UICollectionViewDelegateFlowLayout{
 
 // MARK: Challenge Player Delegate
 
-extension HotChallLearnViewController: ChallengePlayerViewDelegate {
-  func navToTakeChallenge(with data: ChallengeVideo) {
-    coordinator?.navToTakeChallengeViewController(
-      audioFileName: data.mp4FilenameWithoutExtension ?? "",
-      subVideoFilename: data.videoFilename
-    )
-  }
-  
-  func navToLearnChallenge(with data: ChallengeVideo) {
-    coordinator?.navToLearnChallengeViewController(with: data)
-  }
-  
-  func navToShowChallenge(with data: ChallengeVideo) {
-    guard let challenge = data.videoFilename else { return }
-    coordinator?.navToShowChallengeViewController(with: challenge)
-  }
-  
-  func saveChallenge(with data: ChallengeVideo) {
-    CoreDataManager.shared.saveChallenge(with: data) { result in
-      
-      let comment = result ? "챌린지가 저장되었습니다." : "이미 저장된 챌린지입니다."
-      ToastPopupManager.shared.showToast(message: comment, from: self)
-    }
-  }
-}
+//extension HotChallLearnViewController: ChallengePlayerViewDelegate {
+//  func navToTakeChallenge(with data: ChallengeVideo) {
+//    coordinator?.navToTakeChallengeViewController(
+//      audioFileName: data.mp4FilenameWithoutExtension ?? "",
+//      subVideoFilename: data.videoFilename
+//    )
+//  }
+//  
+//  func navToLearnChallenge(with data: ChallengeVideo) {
+//    coordinator?.navToLearnChallengeViewController(with: data)
+//  }
+//  
+//  func navToShowChallenge(with data: ChallengeVideo) {
+//    guard let challenge = data.videoFilename else { return }
+//    coordinator?.navToShowChallengeViewController(with: challenge)
+//  }
+//  
+//  func saveChallenge(with data: ChallengeVideo) {
+//    CoreDataManager.shared.saveChallenge(with: data) { result in
+//      
+//      let comment = result ? "챌린지가 저장되었습니다." : "이미 저장된 챌린지입니다."
+//      ToastPopupManager.shared.showToast(message: comment, from: self)
+//    }
+//  }
+//}
 
 // MARK: SearchBar Delegate
 

--- a/HotChal/HotChal/Scene/SavedChallenge/Coordinator/SavedChallengeCoordinator.swift
+++ b/HotChal/HotChal/Scene/SavedChallenge/Coordinator/SavedChallengeCoordinator.swift
@@ -28,32 +28,32 @@ final class SavedChallengeCoordinator: ChallengePlayerCoordinator {
     self.navigationController.pushViewController(vc, animated: true)
   }
     
-    func navToTakeChallengeViewController(audioFileName: String, subVideoFilename: String?) {
-        lastSubVideoFilename = subVideoFilename
-        let cameraCoordinator = CameraCoordinator(navigationController: navigationController,
-                                                  audioFileName: audioFileName)
-        cameraCoordinator.delegate = self
-        cameraCoordinator.finishDelegate = self
-        childCoordinators.append(cameraCoordinator)
-        cameraCoordinator.start()
-      }
+//    func navToTakeChallengeViewController(audioFileName: String, subVideoFilename: String?) {
+//        lastSubVideoFilename = subVideoFilename
+//        let cameraCoordinator = CameraCoordinator(navigationController: navigationController,
+//                                                  audioFileName: audioFileName)
+//        cameraCoordinator.delegate = self
+//        cameraCoordinator.finishDelegate = self
+//        childCoordinators.append(cameraCoordinator)
+//        cameraCoordinator.start()
+//      }
+//
+//      // (하위호환) 1-파라미터
+//      func navToTakeChallengeViewController(audioFileName: String) {
+//        navToTakeChallengeViewController(audioFileName: audioFileName, subVideoFilename: nil)
+//      }
+//
+//      // 촬영 후 비교화면으로 이동
+//      func navToCompareViewController(url: URL) {
+//        let vc = ChallCompareViewController()
+//        vc.videoURL = url
+//        vc.subVideoFilename = lastSubVideoFilename // ✅ 핵심
+//        vc.coordinator = self
+//        vc.hidesBottomBarWhenPushed = true
+//        navigationController.pushViewController(vc, animated: true)
+//      }
 
-      // (하위호환) 1-파라미터
-      func navToTakeChallengeViewController(audioFileName: String) {
-        navToTakeChallengeViewController(audioFileName: audioFileName, subVideoFilename: nil)
-      }
-
-      // 촬영 후 비교화면으로 이동
-      func navToCompareViewController(url: URL) {
-        let vc = ChallCompareViewController()
-        vc.videoURL = url
-        vc.subVideoFilename = lastSubVideoFilename // ✅ 핵심
-        vc.coordinator = self
-        vc.hidesBottomBarWhenPushed = true
-        navigationController.pushViewController(vc, animated: true)
-      }
-
-      override func didFinishCameraRecording(url: URL) {
-        navToCompareViewController(url: url)
-      }
+//      override func didFinishCameraRecording(url: URL) {
+//        navToCompareViewController(url: url)
+//      }
     }

--- a/HotChal/HotChal/Scene/SavedChallenge/SavedHotChallViewController.swift
+++ b/HotChal/HotChal/Scene/SavedChallenge/SavedHotChallViewController.swift
@@ -225,32 +225,32 @@ extension SavedHotChallViewController: ChallengeHeaderViewActionDelegate{
 ///  MARK: Challenge Player Delegate
 #warning("중복확인필요")
  // ChallengeNavigationDelegate
-extension SavedHotChallViewController: ChallengePlayerViewDelegate {
-  func navToTakeChallenge(with data: ChallengeVideo) {
-
-    coordinator?.navToTakeChallengeViewController(
-      audioFileName: data.mp4FilenameWithoutExtension ?? "",
-      subVideoFilename: data.videoFilename
-    )
-  }
-  
-  func navToLearnChallenge(with data: ChallengeVideo) {
-    coordinator?.navToLearnChallengeViewController(with: data)
-  }
-  
-  func navToShowChallenge(with data: ChallengeVideo) {
-    guard let challenge = data.videoFilename else { return }
-    coordinator?.navToShowChallengeViewController(with: challenge)
-  }
-  
-  func saveChallenge(with data: ChallengeVideo) {
-  
-    guard let uuid = data.id else { return }
-    selectedChallengeUUID = uuid
-    showDeletePopup()
-
-  }
-}
+//extension SavedHotChallViewController: ChallengePlayerViewDelegate {
+//  func navToTakeChallenge(with data: ChallengeVideo) {
+//
+//    coordinator?.navToTakeChallengeViewController(
+//      audioFileName: data.mp4FilenameWithoutExtension ?? "",
+//      subVideoFilename: data.videoFilename
+//    )
+//  }
+//  
+//  func navToLearnChallenge(with data: ChallengeVideo) {
+//    coordinator?.navToLearnChallengeViewController(with: data)
+//  }
+//  
+//  func navToShowChallenge(with data: ChallengeVideo) {
+//    guard let challenge = data.videoFilename else { return }
+//    coordinator?.navToShowChallengeViewController(with: challenge)
+//  }
+//  
+//  func saveChallenge(with data: ChallengeVideo) {
+//  
+//    guard let uuid = data.id else { return }
+//    selectedChallengeUUID = uuid
+//    showDeletePopup()
+//
+//  }
+//}
 
 // MARK: 저장된 챌린지 삭제 Delegate
 

--- a/HotChal/HotChal/Scene/SavedChallenge/SavedHotChallViewController.swift
+++ b/HotChal/HotChal/Scene/SavedChallenge/SavedHotChallViewController.swift
@@ -223,34 +223,11 @@ extension SavedHotChallViewController: ChallengeHeaderViewActionDelegate{
 }
 
 ///  MARK: Challenge Player Delegate
-#warning("중복확인필요")
- // ChallengeNavigationDelegate
-//extension SavedHotChallViewController: ChallengePlayerViewDelegate {
-//  func navToTakeChallenge(with data: ChallengeVideo) {
-//
-//    coordinator?.navToTakeChallengeViewController(
-//      audioFileName: data.mp4FilenameWithoutExtension ?? "",
-//      subVideoFilename: data.videoFilename
-//    )
-//  }
-//  
-//  func navToLearnChallenge(with data: ChallengeVideo) {
-//    coordinator?.navToLearnChallengeViewController(with: data)
-//  }
-//  
-//  func navToShowChallenge(with data: ChallengeVideo) {
-//    guard let challenge = data.videoFilename else { return }
-//    coordinator?.navToShowChallengeViewController(with: challenge)
-//  }
-//  
-//  func saveChallenge(with data: ChallengeVideo) {
-//  
-//    guard let uuid = data.id else { return }
-//    selectedChallengeUUID = uuid
-//    showDeletePopup()
-//
-//  }
-//}
+
+extension SavedHotChallViewController: ChallengePlayerViewDelegate {
+  var challengeNavigationDelegate: ChallengeNavigationDelegate? { coordinator }
+}
+
 
 // MARK: 저장된 챌린지 삭제 Delegate
 


### PR DESCRIPTION
Related Issues
---

- [ #2 ] 

---
## 🔧 작업 내용

### 1. 각 화면 별로 구현되어 있던 PlayerView의 입력 이벤트를 통합

기존에는 각 화면에서 PlayerViewDelegate를 개별 구현하고, 화면 이동을 직접 처리하는 코드가 중복됨

→  ChallengePlayerViewDelegate가 다음을 포함하도록 수정

``` swift
protocol ChallengePlayerViewDelegate: AnyObject {
  var challengeNavigationDelegate: ChallengeNavigationDelegate? { get }
  
  func navToLearnChallenge(with data: ChallengeVideo)
  func navToShowChallenge(with data: ChallengeVideo)
  func navToTakeChallenge(with data: ChallengeVideo)
  func saveChallenge(with data: ChallengeVideo)
}

각 화면에서는 challengeNavigationDelegate만 전달

```

### 2. 각 화면 별로 구현되어 있던 화면이동 로직 제거

---

## 🧪 테스트 체크리스트

* [ ✅] 모든 화면에서 PlayerView -> 배우기, 찍어보기, 보기 화면으로 이동

